### PR TITLE
Update dtedit_demo.R to make it run

### DIFF
--- a/R/dtedit_demo.R
+++ b/R/dtedit_demo.R
@@ -2,7 +2,7 @@
 #'
 #' @export
 dtedit_demo <- function() {
-	dir <- paste0(find.package('DTedit'), '/inst/shiny_demo')
+	dir <- paste0(find.package('DTedit'), '/shiny_demo')
 	message(paste0("Running shiny app from ", dir))
 	shiny::runApp(appDir = dir)
 }


### PR DESCRIPTION
After installing the package using devtools::install_github('jbryer/DTedit'), DTedit::dtedit_demo() doesn't work. I got the following error. I made a small change to get it working.

```
Running shiny app from C:/R/R-3.5.1/library/DTedit/inst/shiny_demo
Error in shinyAppDir(x) : 
  No Shiny application exists at the path "C:/R/R-3.5.1/library/DTedit/inst/shiny_demo"
```

